### PR TITLE
Fix config env variable name

### DIFF
--- a/zeeguu_dashboard/env_var_defs__default.py
+++ b/zeeguu_dashboard/env_var_defs__default.py
@@ -1,3 +1,3 @@
 import os
 
-os.environ['TEACHER_DASHBOARD_CONFIG']=os.path.expanduser('~/<blabla>/teacher_dashboard.cfg')
+os.environ['ZEEGUU_DASHBOARD_CONFIG']=os.path.expanduser('~/<blabla>/teacher_dashboard.cfg')

--- a/zeeguu_dashboard/teacherdash.wsgi
+++ b/zeeguu_dashboard/teacherdash.wsgi
@@ -16,7 +16,7 @@ except:
     print ("didn't find env_var_defs. hopefully there's envvars defined")
 
 
-application.config.from_pyfile(os.environ['TEACHER_DASHBOARD_CONFIG'], silent=False)
+application.config.from_pyfile(os.environ['ZEEGUU_DASHBOARD_CONFIG'], silent=False)
 
 
 bootstrap = Bootstrap(application)


### PR DESCRIPTION
Environment variable name should be ZEEGUU_DASHBOARD_CONFIG as pointed out by README.md and as used in some other code.